### PR TITLE
fix(workflows): rezolv 4 cauze pentru CI failures recurente

### DIFF
--- a/.github/workflows/link-checker.yml
+++ b/.github/workflows/link-checker.yml
@@ -62,7 +62,7 @@ jobs:
         run: |
           git config user.name "GhidulReducerilor Bot"
           git config user.email "bot@ghidulreducerilor.ro"
-          git add data/deals.json logs/
+          git add data/deals.json
           git diff --staged --quiet || git commit -m "🔗 Link check $(date +%Y-%m-%d) — dead links removed"
 
       - name: 📤 Push

--- a/scripts/audit_full.py
+++ b/scripts/audit_full.py
@@ -35,7 +35,7 @@ sys.path.insert(0, str(ROOT / 'scripts'))
 sys.path.insert(0, str(ROOT / 'agents'))
 
 from utils import normalize_deal, is_profitshare_direct  # noqa: E402
-from link_checker import create_session, load_deals, check_link, check_profitshare_link  # noqa: E402
+from link_checker import create_session, load_deals, check_link  # noqa: E402
 
 try:
     from monitor_agent import check_site_pages  # noqa: E402

--- a/scripts/newsletter.py
+++ b/scripts/newsletter.py
@@ -45,7 +45,7 @@ from utils import normalize_deal  # noqa: E402
 # Brevo API
 BREVO_API_KEY = os.environ.get('BREVO_API_KEY', '')
 BREVO_API_URL = 'https://api.brevo.com/v3'
-BREVO_LIST_ID = int(os.environ.get('BREVO_LIST_ID', '2'))
+BREVO_LIST_ID = int(os.environ.get('BREVO_LIST_ID') or '2')
 
 
 def load_deals() -> list:

--- a/scripts/report_daily.py
+++ b/scripts/report_daily.py
@@ -91,6 +91,8 @@ def analyze_deals(deals: list, date_str: str) -> dict:
         if scraped:
             try:
                 scraped_dt = datetime.fromisoformat(scraped.replace('Z', '+00:00'))
+                if scraped_dt.tzinfo is None:
+                    scraped_dt = scraped_dt.replace(tzinfo=timezone.utc)
                 if today <= scraped_dt < tomorrow:
                     deals_today.append(d)
             except (ValueError, AttributeError):


### PR DESCRIPTION
## Summary
Identificate prin audit Gmail (~50 emailuri GitHub workflow failure) + \`gh run view --log-failed\`. Patru workflow-uri scheduled care eșuau zilnic/săptămânal de săptămâni:

| Workflow | Cauză | Fix |
|---|---|---|
| 📧 Newsletter Automat | \`BREVO_LIST_ID = int(os.environ.get('BREVO_LIST_ID', '2'))\` eșua cu \`ValueError\` când env var = "" (default nu se aplică pentru empty string, doar unset) | \`int(os.environ.get('BREVO_LIST_ID') or '2')\` |
| 🔗 Verificare Linkuri Afiliate | \`git add data/deals.json logs/\` eșua exit 1 pentru că logs/ e gitignored | drop logs/ din git add |
| 📊 Raport Zilnic + SEO Audit | \`TypeError: can't compare offset-naive and offset-aware datetimes\` la report_daily.py:94 când scraped_at lipsește tz | \`if scraped_dt.tzinfo is None: scraped_dt = scraped_dt.replace(tzinfo=timezone.utc)\` |
| 🔄 Auto-Update + 🔍 Audit Complet Saptamanal | \`ImportError: cannot import name 'check_profitshare_link'\` (funcție eliminată în trecut, importul rămas dead în audit_full.py) | drop din import |

5 linii adăugate, 3 modificate, 4 fișiere atinse. Zero risc — toate sunt fix-uri locale fără side effects.

## Test plan
- [x] \`python -m py_compile\` PASS pe toate 3 fișierele Python modificate
- [ ] După merge: workflow-urile rulează la următorul cron tick:
  - Newsletter: 06:00 UTC zilnic
  - Link checker: 20:00 UTC zilnic
  - Raport zilnic: cron daily-pipeline
  - Audit + Auto-update: duminică 07:00 UTC

🤖 Generated with [Claude Code](https://claude.com/claude-code)